### PR TITLE
Fixed deprecated warnings in iOS 6.0

### DIFF
--- a/DejalActivityView.m
+++ b/DejalActivityView.m
@@ -58,9 +58,9 @@ static DejalActivityView *dejalActivityView = nil;
 
 /*
  currentActivityView
- 
+
  Returns the currently displayed activity view, or nil if there isn't one.
- 
+
  Written by DJS 2009-07.
 */
 
@@ -71,9 +71,9 @@ static DejalActivityView *dejalActivityView = nil;
 
 /*
  activityViewForView:
- 
+
  Creates and adds an activity view centered within the specified view, using the label "Loading...".  Returns the activity view, already added as a subview of the specified view.
- 
+
  Written by DJS 2009-07.
  Changed by DJS 2010-06 to add "new" prefix to the method name to make it clearer that this returns a retained object.
  Changed by DJS 2011-08 to remove the "new" prefix again.
@@ -86,9 +86,9 @@ static DejalActivityView *dejalActivityView = nil;
 
 /*
  activityViewForView:withLabel:
- 
+
  Creates and adds an activity view centered within the specified view, using the specified label.  Returns the activity view, already added as a subview of the specified view.
- 
+
  Written by DJS 2009-07.
  Changed by DJS 2010-06 to add "new" prefix to the method name to make it clearer that this returns a retained object.
  Changed by DJS 2011-08 to remove the "new" prefix again.
@@ -101,9 +101,9 @@ static DejalActivityView *dejalActivityView = nil;
 
 /*
  activityViewForView:withLabel:width:
- 
+
  Creates and adds an activity view centered within the specified view, using the specified label and a fixed label width.  The fixed width is useful if you want to change the label text while the view is visible.  Returns the activity view, already added as a subview of the specified view.
- 
+
  Written by DJS 2009-07.
  Changed by DJS 2010-06 to add "new" prefix to the method name to make it clearer that this returns a retained object.
  Changed by DJS 2011-08 to remove the "new" prefix again, and move the singleton stuff to here.
@@ -114,18 +114,18 @@ static DejalActivityView *dejalActivityView = nil;
     // Immediately remove any existing activity view:
     if (dejalActivityView)
         [self removeView];
-    
+
     // Remember the new view (so this is a singleton):
     dejalActivityView = [[self alloc] initForView:addToView withLabel:labelText width:aLabelWidth];
-    
+
     return dejalActivityView;
 }
 
 /*
  initForView:withLabel:width:
- 
+
  Designated initializer.  Configures the activity view using the specified label text and width, and adds as a subview of the specified view.
- 
+
  Written by DJS 2009-07.
  Changed by DJS 2011-08 to move the singleton stuff to the calling class method, where it should be.
 */
@@ -134,27 +134,27 @@ static DejalActivityView *dejalActivityView = nil;
 {
 	if (!(self = [super initWithFrame:CGRectZero]))
 		return nil;
-	
+
     // Allow subclasses to change the view to which to add the activity view (e.g. to cover the keyboard):
     self.originalView = addToView;
     addToView = [self viewForView:addToView];
-    
+
     // Configure this view (the background) and its subviews:
     [self setupBackground];
     self.labelWidth = aLabelWidth;
     self.borderView = [self makeBorderView];
     self.activityIndicator = [self makeActivityIndicator];
     self.activityLabel = [self makeActivityLabelWithText:labelText];
-    
+
     // Assemble the subviews:
 	[addToView addSubview:self];
     [self addSubview:self.borderView];
     [self.borderView addSubview:self.activityIndicator];
     [self.borderView addSubview:self.activityLabel];
-    
+
 	// Animate the view in, if appropriate:
 	[self animateShow];
-    
+
 	return self;
 }
 
@@ -166,9 +166,9 @@ static DejalActivityView *dejalActivityView = nil;
 
 /*
  removeView
- 
+
  Immediately removes and releases the view without any animation.
- 
+
  Written by DJS 2009-07.
  Changed by DJS 2009-09 to disable the network activity indicator if it was shown by this view.
 */
@@ -177,21 +177,21 @@ static DejalActivityView *dejalActivityView = nil;
 {
     if (!dejalActivityView)
         return;
-    
+
     if (dejalActivityView.showNetworkActivityIndicator)
         [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
-    
+
     [dejalActivityView removeFromSuperview];
-    
+
     // Remove the global reference:
     dejalActivityView = nil;
 }
 
 /*
  viewForView:
- 
+
  Returns the view to which to add the activity view.  By default returns the same view.  Subclasses may override this to change the view.
- 
+
  Written by DJS 2009-07.
 */
 
@@ -202,9 +202,9 @@ static DejalActivityView *dejalActivityView = nil;
 
 /*
  enclosingFrame
- 
+
  Returns the frame to use for the activity view.  Defaults to the superview's bounds.  Subclasses may override this to use something different, if desired.
- 
+
  Written by DJS 2009-07.
 */
 
@@ -215,9 +215,9 @@ static DejalActivityView *dejalActivityView = nil;
 
 /*
  setupBackground
- 
+
  Configure the background of the activity view.
- 
+
  Written by DJS 2009-07.
 */
 
@@ -229,9 +229,9 @@ static DejalActivityView *dejalActivityView = nil;
 
 /*
  makeBorderView
- 
+
  Returns a new view to contain the activity indicator and label.  By default this view is transparent.  Subclasses may override this method, optionally calling super, to use a different or customized view.
- 
+
  Written by DJS 2009-07.
  Changed by DJS 2011-11 to simplify and make it easier to override.
 */
@@ -239,18 +239,18 @@ static DejalActivityView *dejalActivityView = nil;
 - (UIView *)makeBorderView;
 {
     UIView *view = [[UIView alloc] initWithFrame:CGRectZero];
-    
+
     view.opaque = NO;
     view.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
-    
+
     return view;
 }
 
 /*
  makeActivityIndicator
- 
+
  Returns a new activity indicator view.  Subclasses may override this method, optionally calling super, to use a different or customized view.
- 
+
  Written by DJS 2009-07.
  Changed by DJS 2011-11 to simplify and make it easier to override.
 */
@@ -258,17 +258,17 @@ static DejalActivityView *dejalActivityView = nil;
 - (UIActivityIndicatorView *)makeActivityIndicator;
 {
     UIActivityIndicatorView *indicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
-    
+
     [indicator startAnimating];
-    
+
     return indicator;
 }
 
 /*
  makeActivityLabelWithText:
- 
+
  Returns a new activity label.  Subclasses may override this method, optionally calling super, to use a different or customized view.
- 
+
  Written by DJS 2009-07.
  Changed by DJS 2011-11 to simplify and make it easier to override.
 */
@@ -276,42 +276,42 @@ static DejalActivityView *dejalActivityView = nil;
 - (UILabel *)makeActivityLabelWithText:(NSString *)labelText;
 {
     UILabel *label = [[UILabel alloc] initWithFrame:CGRectZero];
-    
+
     label.font = [UIFont systemFontOfSize:[UIFont systemFontSize]];
-    label.textAlignment = UITextAlignmentLeft;
+    label.textAlignment = NSTextAlignmentLeft;
     label.textColor = [UIColor blackColor];
     label.backgroundColor = [UIColor clearColor];
     label.shadowColor = [UIColor whiteColor];
     label.shadowOffset = CGSizeMake(0.0, 1.0);
     label.text = labelText;
-    
+
     return label;
 }
 
 /*
  layoutSubviews
- 
+
  Positions and sizes the various views that make up the activity view, including after rotation.
- 
+
  Written by DJS 2009-07.
 */
 
 - (void)layoutSubviews;
 {
     self.frame = [self enclosingFrame];
-    
+
     // If we're animating a transform, don't lay out now, as can't use the frame property when transforming:
     if (!CGAffineTransformIsIdentity(self.borderView.transform))
         return;
-    
+
     CGSize textSize = [self.activityLabel.text sizeWithFont:[UIFont systemFontOfSize:[UIFont systemFontSize]]];
-    
+
     // Use the fixed width if one is specified:
     if (self.labelWidth > 10)
         textSize.width = self.labelWidth;
-    
+
     self.activityLabel.frame = CGRectMake(self.activityLabel.frame.origin.x, self.activityLabel.frame.origin.y, textSize.width, textSize.height);
-    
+
     // Calculate the size and position for the border view: with the indicator to the left of the label, and centered in the receiver:
 	CGRect borderFrame = CGRectZero;
     borderFrame.size.width = self.activityIndicator.frame.size.width + textSize.width + 25.0;
@@ -319,13 +319,13 @@ static DejalActivityView *dejalActivityView = nil;
     borderFrame.origin.x = floor(0.5 * (self.frame.size.width - borderFrame.size.width));
     borderFrame.origin.y = floor(0.5 * (self.frame.size.height - borderFrame.size.height - 20.0));
     self.borderView.frame = borderFrame;
-	
+
     // Calculate the position of the indicator: vertically centered and at the left of the border view:
     CGRect indicatorFrame = self.activityIndicator.frame;
 	indicatorFrame.origin.x = 10.0;
 	indicatorFrame.origin.y = 0.5 * (borderFrame.size.height - indicatorFrame.size.height);
     self.activityIndicator.frame = indicatorFrame;
-    
+
     // Calculate the position of the label: vertically centered and at the right of the border view:
 	CGRect labelFrame = self.activityLabel.frame;
     labelFrame.origin.x = borderFrame.size.width - labelFrame.size.width - 10.0;
@@ -335,9 +335,9 @@ static DejalActivityView *dejalActivityView = nil;
 
 /*
  animateShow
- 
+
  Animates the view into visibility.  Does nothing for the simple activity view.
- 
+
  Written by DJS 2009-07.
 */
 
@@ -348,9 +348,9 @@ static DejalActivityView *dejalActivityView = nil;
 
 /*
  animateRemove
- 
+
  Animates the view out of visibiltiy.  Does nothng for the simple activity view.
- 
+
  Written by DJS 2009-07.
 */
 
@@ -361,16 +361,16 @@ static DejalActivityView *dejalActivityView = nil;
 
 /*
  setShowNetworkActivityIndicator:
- 
+
  Sets whether or not to show the network activity indicator in the status bar.  Set to YES if the activity is network-related.  This can be toggled on and off as desired while the activity view is visible (e.g. have it on while fetching data, then disable it while parsing it).  By default it is not shown.
- 
+
  Written by DJS 2009-09.
 */
 
 - (void)setShowNetworkActivityIndicator:(BOOL)show;
 {
     showNetworkActivityIndicator = show;
-    
+
     [UIApplication sharedApplication].networkActivityIndicatorVisible = show;
 }
 
@@ -386,9 +386,9 @@ static DejalActivityView *dejalActivityView = nil;
 
 /*
  makeActivityIndicator
- 
+
  Returns a new activity indicator view.  This subclass uses a white activity indicator instead of gray.
- 
+
  Written by DJS 2009-10.
  Changed by DJS 2011-11 to simplify and make it easier to override.
 */
@@ -396,17 +396,17 @@ static DejalActivityView *dejalActivityView = nil;
 - (UIActivityIndicatorView *)makeActivityIndicator;
 {
     UIActivityIndicatorView *indicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhite];
-    
+
     [indicator startAnimating];
-    
+
     return indicator;
 }
 
 /*
  makeActivityLabelWithText:
- 
+
  Returns a new activity label.  This subclass uses white text instead of black.
- 
+
  Written by DJS 2009-10.
  Changed by DJS 2011-11 to simplify and make it easier to override.
 */
@@ -414,10 +414,10 @@ static DejalActivityView *dejalActivityView = nil;
 - (UILabel *)makeActivityLabelWithText:(NSString *)labelText;
 {
     UILabel *label = [super makeActivityLabelWithText:labelText];
-    
+
     label.textColor = [UIColor whiteColor];
     label.shadowColor = [UIColor blackColor];
-    
+
     return label;
 }
 
@@ -433,60 +433,60 @@ static DejalActivityView *dejalActivityView = nil;
 
 /*
  viewForView:
- 
+
  Returns the view to which to add the activity view.  For the bezel style, if there is a keyboard displayed, the view is changed to the keyboard's superview.
- 
+
  Written by DJS 2009-07.
 */
 
 - (UIView *)viewForView:(UIView *)view;
 {
     UIView *keyboardView = [[UIApplication sharedApplication] keyboardView];
-    
+
     if (keyboardView)
         view = keyboardView.superview;
-    
+
     return view;
 }
 
 /*
  enclosingFrame
- 
+
  Returns the frame to use for the activity view.  For the bezel style, if there is a keyboard displayed, the frame is changed to cover the keyboard too.
- 
+
  Written by DJS 2009-07.
 */
 
 - (CGRect)enclosingFrame;
 {
     CGRect frame = [super enclosingFrame];
-    
+
     if (self.superview != self.originalView)
         frame = [self.originalView convertRect:self.originalView.bounds toView:self.superview];
-    
+
     return frame;
 }
 
 /*
  setupBackground
- 
+
  Configure the background of the activity view.
- 
+
  Written by DJS 2009-07.
 */
 
 - (void)setupBackground;
 {
     [super setupBackground];
-    
+
 	self.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.35];
 }
 
 /*
  makeBorderView
- 
+
  Returns a new view to contain the activity indicator and label.  The bezel style has a semi-transparent rounded rectangle.
- 
+
  Written by DJS 2009-07.
  Changed by DJS 2011-11 to simplify and make it easier to override.
 */
@@ -494,18 +494,18 @@ static DejalActivityView *dejalActivityView = nil;
 - (UIView *)makeBorderView;
 {
     UIView *view = [super makeBorderView];
-    
+
     view.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.5];
     view.layer.cornerRadius = 10.0;
-    
+
     return view;
 }
 
 /*
  makeActivityIndicator
- 
+
  Returns a new activity indicator view.  The bezel style uses a large white indicator.
- 
+
  Written by DJS 2009-07.
  Changed by DJS 2011-11 to simplify and make it easier to override.
 */
@@ -513,17 +513,17 @@ static DejalActivityView *dejalActivityView = nil;
 - (UIActivityIndicatorView *)makeActivityIndicator;
 {
     UIActivityIndicatorView *indicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
-    
+
     [indicator startAnimating];
-    
+
     return indicator;
 }
 
 /*
  makeActivityLabelWithText:
- 
+
  Returns a new activity label.  The bezel style uses centered white text.
- 
+
  Written by DJS 2009-07.
  Changed by Suleman Sidat 2011-07 to support a multi-line label.
  Changed by DJS 2011-11 to simplify and make it easier to override.
@@ -532,23 +532,23 @@ static DejalActivityView *dejalActivityView = nil;
 - (UILabel *)makeActivityLabelWithText:(NSString *)labelText;
 {
     UILabel *label = [[UILabel alloc] initWithFrame:CGRectZero];
-    
+
     label.font = [UIFont boldSystemFontOfSize:[UIFont systemFontSize]];
-    label.textAlignment = UITextAlignmentCenter;
+    label.textAlignment = NSTextAlignmentCenter;
     label.textColor = [UIColor whiteColor];
     label.backgroundColor = [UIColor clearColor];
     label.numberOfLines = 0;
-    label.lineBreakMode = UILineBreakModeWordWrap; 
+    label.lineBreakMode = NSLineBreakByWordWrapping;
     label.text = labelText;
-    
+
     return label;
 }
 
 /*
  layoutSubviews
- 
+
  Positions and sizes the various views that make up the activity view, including after rotation.
- 
+
  Written by DJS 2009-07.
  Changed by Suleman Sidat 2011-07 to support a multi-line label.
 */
@@ -558,26 +558,26 @@ static DejalActivityView *dejalActivityView = nil;
     // If we're animating a transform, don't lay out now, as can't use the frame property when transforming:
     if (!CGAffineTransformIsIdentity(self.borderView.transform))
         return;
-    
+
     self.frame = [self enclosingFrame];
-    
+
     CGSize maxSize = CGSizeMake(260, 400);
     CGSize textSize = [self.activityLabel.text sizeWithFont:[UIFont boldSystemFontOfSize:[UIFont systemFontSize]] constrainedToSize:maxSize lineBreakMode:self.activityLabel.lineBreakMode];
-    
+
     // Use the fixed width if one is specified:
     if (self.labelWidth > 10)
         textSize.width = self.labelWidth;
-    
+
     // Require that the label be at least as wide as the indicator, since that width is used for the border view:
     if (textSize.width < self.activityIndicator.frame.size.width)
         textSize.width = self.activityIndicator.frame.size.width + 10.0;
-    
+
     // If there's no label text, don't need to allow height for it:
     if (self.activityLabel.text.length == 0)
         textSize.height = 0.0;
-    
+
     self.activityLabel.frame = CGRectMake(self.activityLabel.frame.origin.x, self.activityLabel.frame.origin.y, textSize.width, textSize.height);
-    
+
     // Calculate the size and position for the border view: with the indicator vertically above the label, and centered in the receiver:
 	CGRect borderFrame = CGRectZero;
     borderFrame.size.width = textSize.width + 30.0;
@@ -585,13 +585,13 @@ static DejalActivityView *dejalActivityView = nil;
     borderFrame.origin.x = floor(0.5 * (self.frame.size.width - borderFrame.size.width));
     borderFrame.origin.y = floor(0.5 * (self.frame.size.height - borderFrame.size.height));
     self.borderView.frame = borderFrame;
-	
+
     // Calculate the position of the indicator: horizontally centered and near the top of the border view:
     CGRect indicatorFrame = self.activityIndicator.frame;
 	indicatorFrame.origin.x = 0.5 * (borderFrame.size.width - indicatorFrame.size.width);
 	indicatorFrame.origin.y = 20.0;
     self.activityIndicator.frame = indicatorFrame;
-    
+
     // Calculate the position of the label: horizontally centered and near the bottom of the border view:
 	CGRect labelFrame = self.activityLabel.frame;
     labelFrame.origin.x = floor(0.5 * (borderFrame.size.width - labelFrame.size.width));
@@ -601,9 +601,9 @@ static DejalActivityView *dejalActivityView = nil;
 
 /*
  animateShow
- 
+
  Animates the view into visibility.  For the bezel style, fades in the background and zooms the bezel down from a large size.
- 
+
  Written by DJS 2009-07.
 */
 
@@ -611,21 +611,21 @@ static DejalActivityView *dejalActivityView = nil;
 {
     self.alpha = 0.0;
     self.borderView.transform = CGAffineTransformMakeScale(3.0, 3.0);
-    
+
 	[UIView beginAnimations:nil context:nil];
 //	[UIView setAnimationDuration:5.0];            // Uncomment to see the animation in slow motion
-	
+
     self.borderView.transform = CGAffineTransformIdentity;
     self.alpha = 1.0;
-    
+
 	[UIView commitAnimations];
 }
 
 /*
  animateRemove
- 
+
  Animates the view out, deferring the removal until the animation is complete.  For the bezel style, fades out the background and zooms the bezel down to half size.
- 
+
  Written by DJS 2009-07.
  Changed by DJS 2009-09 to disable the network activity indicator if it was shown by this view.
 */
@@ -634,17 +634,17 @@ static DejalActivityView *dejalActivityView = nil;
 {
     if (self.showNetworkActivityIndicator)
         [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
-    
+
     self.borderView.transform = CGAffineTransformIdentity;
-    
+
 	[UIView beginAnimations:nil context:nil];
 //	[UIView setAnimationDuration:5.0];            // Uncomment to see the animation in slow motion
 	[UIView setAnimationDelegate:self];
 	[UIView setAnimationDidStopSelector:@selector(removeAnimationDidStop:finished:context:)];
-	
+
     self.borderView.transform = CGAffineTransformMakeScale(0.5, 0.5);
     self.alpha = 0.0;
-    
+
 	[UIView commitAnimations];
 }
 
@@ -655,9 +655,9 @@ static DejalActivityView *dejalActivityView = nil;
 
 /*
  removeViewAnimated:
- 
+
  Animates the view out from the superview and releases it, or simply removes and releases it immediately if not animating.
- 
+
  Written by DJS 2009-07.
 */
 
@@ -665,7 +665,7 @@ static DejalActivityView *dejalActivityView = nil;
 {
     if (!dejalActivityView)
         return;
-    
+
     if (animated)
         [dejalActivityView animateRemove];
     else
@@ -684,9 +684,9 @@ static DejalActivityView *dejalActivityView = nil;
 
 /*
  activityView
- 
+
  Creates and adds a keyboard-style activity view, using the label "Loading...".  Returns the activity view, already covering the keyboard, or nil if the keyboard isn't currently displayed.
- 
+
  Written by DJS 2009-07.
  Changed by DJS 2010-06 to add "new" prefix to the method name to make it clearer that this returns a retained object.
  Changed by DJS 2011-08 to remove the "new" prefix again.
@@ -699,9 +699,9 @@ static DejalActivityView *dejalActivityView = nil;
 
 /*
  activityViewWithLabel:
- 
+
  Creates and adds a keyboard-style activity view, using the specified label.  Returns the activity view, already covering the keyboard, or nil if the keyboard isn't currently displayed.
- 
+
  Written by DJS 2009-07.
  Changed by DJS 2010-06 to add "new" prefix to the method name to make it clearer that this returns a retained object.
  Changed by DJS 2011-08 to remove the "new" prefix again.
@@ -710,7 +710,7 @@ static DejalActivityView *dejalActivityView = nil;
 + (DejalKeyboardActivityView *)activityViewWithLabel:(NSString *)labelText;
 {
     UIView *keyboardView = [[UIApplication sharedApplication] keyboardView];
-    
+
     if (!keyboardView)
         return nil;
     else
@@ -719,9 +719,9 @@ static DejalActivityView *dejalActivityView = nil;
 
 /*
  viewForView:
- 
+
  Returns the view to which to add the activity view.  For the keyboard style, returns the same view (which will already be the keyboard).
- 
+
  Written by DJS 2009-07.
 */
 
@@ -732,29 +732,29 @@ static DejalActivityView *dejalActivityView = nil;
 
 /*
  animateShow
- 
+
  Animates the view into visibility.  For the keyboard style, simply fades in.
- 
+
  Written by DJS 2009-07.
 */
 
 - (void)animateShow;
 {
     self.alpha = 0.0;
-    
+
 	[UIView beginAnimations:nil context:nil];
 	[UIView setAnimationDuration:1.0];
-	
+
     self.alpha = 1.0;
-    
+
 	[UIView commitAnimations];
 }
 
 /*
  animateRemove
- 
+
  Animates the view out, deferring the removal until the animation is complete.  For the keyboard style, simply fades out.
- 
+
  Written by DJS 2009-07.
 */
 
@@ -764,32 +764,32 @@ static DejalActivityView *dejalActivityView = nil;
 	[UIView setAnimationDuration:1.0];
 	[UIView setAnimationDelegate:self];
 	[UIView setAnimationDidStopSelector:@selector(removeAnimationDidStop:finished:context:)];
-	
+
     self.alpha = 0.0;
-    
+
 	[UIView commitAnimations];
 }
 
 /*
  setupBackground
- 
+
  Configure the background of the activity view.
- 
+
  Written by DJS 2009-07.
 */
 
 - (void)setupBackground;
 {
     [super setupBackground];
-    
+
     self.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.85];
 }
 
 /*
  makeBorderView
- 
+
  Returns a new view to contain the activity indicator and label.  The keyboard style has a transparent border.
- 
+
  Written by DJS 2009-07.
  Changed by DJS 2011-11 to simplify and make it easier to override.
 */
@@ -797,9 +797,9 @@ static DejalActivityView *dejalActivityView = nil;
 - (UIView *)makeBorderView;
 {
     UIView *view = [super makeBorderView];
-    
+
     view.backgroundColor = nil;
-    
+
     return view;
 }
 
@@ -816,7 +816,7 @@ static DejalActivityView *dejalActivityView = nil;
 //  keyboardView
 //
 //  Copyright Matt Gallagher 2009. All rights reserved.
-// 
+//
 //  Permission is given to use this source code file, free of charge, in any
 //  project, commercial or otherwise, entirely at your risk, with the condition
 //  that any redistribution (in part or whole) of source code must retain
@@ -837,7 +837,7 @@ static DejalActivityView *dejalActivityView = nil;
 			}
 		}
 	}
-	
+
 	return nil;
 }
 


### PR DESCRIPTION
The enums 
- `UITextAlignmentCenter`
- `UITextAlignmentLeft`
- `UILineBreakModeWordWrap` 

are deprecated in iOS 6. I replaced them with their AppKit equivalents.
